### PR TITLE
Armelvil working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ webfiles/root/usr/local/bin/.wavelet_encoder.sh.~7a0497bb
 webfiles/root/usr/local/bin/.wavelet_controller.sh.~3b4fab4a
 ignition_files/.ignition_encoder.yml.~660b393b
 .coreos_installer.sh.~692bff20
+fedora-coreos-40.20240504.3.0-live.x86_64.iso

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ webfiles/root/usr/local/bin/.wavelet_controller.sh.~3b4fab4a
 ignition_files/.ignition_encoder.yml.~660b393b
 .coreos_installer.sh.~692bff20
 fedora-coreos-40.20240504.3.0-live.x86_64.iso
+webfiles/root/usr/local/bin/build_httpd_quadlet.sh

--- a/ignition_files/ignition_server.yml
+++ b/ignition_files/ignition_server.yml
@@ -86,12 +86,6 @@ storage:
       overwrite: true
       contents:
         source: https://raw.githubusercontent.com/Allethrium/wavelet/master/webfiles/root/etc/containers/registries.conf.d/10-wavelet.conf
-    # Force Podman 5.0 to use slirp4netns backend, pasta networking backend breaks inter-container communication
-    - path: /usr/share/containers/containers.conf
-      mode: 0644
-      overwrite: true
-      contents:
-        source: https://raw.githubusercontent.com/Allethrium/wavelet/master/webfiles/root/usr/share/containers/containers.conf
     # Installer script to handle ostree overlay and git clone
     - path: /usr/local/bin/wavelet-installer_xf.sh
       mode: 0644

--- a/ignition_files/ignition_server.yml
+++ b/ignition_files/ignition_server.yml
@@ -86,6 +86,12 @@ storage:
       overwrite: true
       contents:
         source: https://raw.githubusercontent.com/Allethrium/wavelet/master/webfiles/root/etc/containers/registries.conf.d/10-wavelet.conf
+    # Force Podman 5.0 to use slirp4netns backend, pasta networking backend breaks inter-container communication
+    - path: /usr/share/containers/containers.conf
+      mode: 0644
+      overwrite: true
+      contents:
+        source: https://raw.githubusercontent.com/Allethrium/wavelet/master/webfiles/root/usr/share/containers/containers.conf
     # Installer script to handle ostree overlay and git clone
     - path: /usr/local/bin/wavelet-installer_xf.sh
       mode: 0644
@@ -123,8 +129,8 @@ storage:
          name=Intel® oneAPI repository
          baseurl=https://yum.repos.intel.com/oneapi
          enabled=1
-         gpgcheck=1
-         repo_gpgcheck=1
+         gpgcheck=0
+         repo_gpgcheck=0
          gpgkey=https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
     # TEST Snapcast Jwillikers COPR repository
     - path: /etc/yum.repos.d/jwillikers-snapcast.repo

--- a/ignition_files/ignition_server.yml
+++ b/ignition_files/ignition_server.yml
@@ -27,7 +27,7 @@ storage:
       mode: 0755
       overwrite: true
       contents:
-        source: https://github.com/CESNET/UltraGrid/releases/download/v1.9.1/UltraGrid-1.9.1-x86_64.AppImage
+        source: https://github.com/CESNET/UltraGrid/releases/download/v1.9.3/UltraGrid-1.9.3-x86_64.AppImage
     # WiFi WiFi Name
     - path: /var/home/wavelet/wifi_ssid
       overwrite: true
@@ -126,6 +126,22 @@ storage:
          gpgcheck=1
          repo_gpgcheck=1
          gpgkey=https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+    # TEST Snapcast Jwillikers COPR repository
+    - path: /etc/yum.repos.d/jwillikers-snapcast.repo
+      mode: 0664
+      overwrite: true
+      contents:
+        inline: |
+         [copr:copr.fedorainfracloud.org:jwillikers:snapcast]
+         name=Copr repo for snapcast owned by jwillikers
+         baseurl=https://download.copr.fedorainfracloud.org/results/jwillikers/snapcast/fedora-$releasever-$basearch/
+         type=rpm-md
+         skip_if_unavailable=True
+         gpgcheck=1
+         gpgkey=https://download.copr.fedorainfracloud.org/results/jwillikers/snapcast/pubkey.gpg
+         repo_gpgcheck=0
+         enabled=1
+         enabled_metadata=1
     # PolKit entries for systemd services the wavelet user is allowed to manage
     - path: /etc/polkit-1/rules.d/1337-wavelet.rules
       mode: 0644

--- a/webfiles/root/etc/dnsmasq.conf
+++ b/webfiles/root/etc/dnsmasq.conf
@@ -30,6 +30,9 @@ dhcp-rapid-commit
 cache-size=32
 resolv-file=/etc/dnsmasq.d/dnsmasq-resolv.conf
 
+# Add IP lease sense
+dhcp-script=/usr/local/bin/wavelet_network_sense.sh
+
 # Public DNS servers
 server=192.168.1.1
 server=9.9.9.9

--- a/webfiles/root/usr/local/bin/connectwifi.sh
+++ b/webfiles/root/usr/local/bin/connectwifi.sh
@@ -2,11 +2,12 @@
 # Attempts to find and join a Wavelet network if it's available
 
 # These are now defined by inline files in ignition so they can be "securely" customized ahead of time
-networkssid=$(echo /var/home/wavelet/wifi_ssid)
-wifipassword=$(echo /var/home/wavelet/wifi_pw)
-wifi_ap_mac=$(echo /var/home/wavelet/wifi_bssid)
+networkssid=$(cat /var/home/wavelet/wifi_ssid)
+wifipassword=$(cat /var/home/wavelet/wifi_pw)
+wifi_ap_mac=$(cat /var/home/wavelet/wifi_bssid)
 
 connectwifi(){
+# 5/28/2024 - fix echo to cat so connectwifi spits out proper values and connects appropriately.
 	nmcli dev wifi rescan
 	sleep 5
 	nmcli dev wifi rescan

--- a/webfiles/root/usr/local/bin/wavelet_installer_xf.sh
+++ b/webfiles/root/usr/local/bin/wavelet_installer_xf.sh
@@ -65,7 +65,7 @@ rpm_ostree_install(){
 -y -A \
 wget fontawesome-fonts wl-clipboard nnn mako sway bemenu rofi-wayland lxsession sway-systemd waybar \
 foot vim powerline powerline-fonts vim-powerline NetworkManager-wifi iw wireless-regdb wpa_supplicant \
-cockpit-bridge cockpit-networkmanager cockpit-system cockpit-ostree cockpit-podman buildah rdma \
+cockpit-bridge cockpit-networkmanager cockpit-system cockpit-ostree cockpit-podman buildah rdma avahi \
 iwlwifi-dvm-firmware.noarch iwlwifi-mvm-firmware.noarch etcd dnf yum-utils createrepo sha \
 libsrtp libdrm python3-pip srt srt-libs libv4l v4l-utils libva-v4l2-request pipewire-v4l2 \
 ImageMagick intel-opencl mesa-dri-drivers mesa-vulkan-drivers mesa-vdpau-drivers libdrm mesa-libEGL mesa-libgbm mesa-libGL \
@@ -93,7 +93,8 @@ libva-intel-driver \
 ffmpeg ffmpeg-libs libheif-freeworld \
 neofetch htop \
 mesa-libOpenCL python3-pip srt srt-libs ffmpeg vlc libv4l v4l-utils libva-v4l2-request pipewire-v4l2 \
-ImageMagick mplayer
+ImageMagick mplayer \
+libndi libndi-devel ndi-sdk obs-ndi
 echo -e "RPMFusion Media Packages installed, waiting for 2 seconds..\n"
 sleep 2
 


### PR DESCRIPTION
this will likely break everything however need to test rapidly.
Currently as of Podman5/FedoraCoreOS 40 the network backend changed from SLIRP to PASST, and this breaks inter-container communication between the webUI frontend and the etcd container.

changes args to compensate for new podmanv5 PASST network backend.  May not need all args.

I had hoped to use quadlets but I'm finding the documentation very hard to work through, and generating the nginx+PHP pod seems to be problematic.  May just rewrite with kubernetes yaml at a later date, as that seems to be the most common example workflow.