### PR TITLE
- revert Intel OneAPI GPG Check

### DIFF
--- a/ignition_files/ignition_server.yml
+++ b/ignition_files/ignition_server.yml
@@ -129,8 +129,8 @@ storage:
          name=Intel® oneAPI repository
          baseurl=https://yum.repos.intel.com/oneapi
          enabled=1
-         gpgcheck=1
-         repo_gpgcheck=1
+         gpgcheck=0
+         repo_gpgcheck=0
          gpgkey=https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
     # PolKit entries for systemd services the wavelet user is allowed to manage
     - path: /etc/polkit-1/rules.d/1337-wavelet.rules

--- a/webfiles/root/usr/local/bin/wavelet_installer_xf.sh
+++ b/webfiles/root/usr/local/bin/wavelet_installer_xf.sh
@@ -94,14 +94,9 @@ ffmpeg ffmpeg-libs libheif-freeworld \
 neofetch htop \
 mesa-libOpenCL python3-pip srt srt-libs ffmpeg vlc libv4l v4l-utils libva-v4l2-request pipewire-v4l2 \
 ImageMagick mplayer \
-libndi libndi-devel ndi-sdk obs-ndi
-echo -e "RPMFusion Media Packages installed, waiting for 2 seconds..\n"
-sleep 2
-
-/usr/bin/rpm-ostree install \
--y -A --idempotent \
+libndi libndi-devel ndi-sdk obs-ndi \
 firefox
-echo -e "Firefox installed for local console capability, waiting for two seconds..\n"
+echo -e "RPMFusion Media Packages installed, waiting for 2 seconds..\n"
 sleep 2
 
 touch /var/rpm-ostree-overlay.complete


### PR DESCRIPTION
- disable gpg checking on OneAPI (didn't I already do this once?)
- move firefox package to second overlay task.